### PR TITLE
use smtlib2-0.3.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "smtlib2"]
-	path = smtlib2
-	url = https://github.com/pseudometric/smtlib2.git
-	branch = res

--- a/src/makefile
+++ b/src/makefile
@@ -1,7 +1,5 @@
 .PHONY: default
 
 default:
-	git submodule update --init
 	cabal sandbox init
-	(cd ../smtlib2; cabal --sandbox-config-file=../src/cabal.sandbox.config install)
 	cabal install --bindir=$(CURDIR)/../bin

--- a/src/razor.cabal
+++ b/src/razor.cabal
@@ -52,7 +52,7 @@ executable razor
      parsec >=3.1 && <3.2,
      process >=1.2 && <1.5,
      safe >=0.3.9 && < 0.4,
-     smtlib2 >=0.2 && <0.4,
+     smtlib2 >=0.3.1 && <0.4,
      text >=0.11 && <1.3,
      vector >=0.10 && <0.12,
      base >=4.6


### PR DESCRIPTION
My smtlib2 fixes have been accepted upstream and published on Hackage as smtlib2-0.3.1; remove my interim version and use that. Run `cabal update` first to make sure you have the new version in your Hackage index. Also remove your existing sandbox to start from a clean slate; you can use `git clean -d` assuming that won’t blow any other untracked files you have lying around.
